### PR TITLE
Fix default value of length in get_block_locations

### DIFF
--- a/hdfs.py
+++ b/hdfs.py
@@ -111,7 +111,7 @@ class HDFileSystem():
         assert self._handle, "Filesystem not connected"
         return HDFile(self, path, mode, **kwargs)
         
-    def get_block_locations(self, path, start=0, length=None):
+    def get_block_locations(self, path, start=0, length=0):
         "Fetch physical locations of blocks"
         assert self._handle, "Filesystem not connected"
         fi = self.info(path)


### PR DESCRIPTION
Fixes the error:

```python
In [13]: fs.get_block_locations('blah.txt')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-13-c463c7159784> in <module>()
----> 1 fs.get_block_locations('blah.txt')

/home/ubuntu/libhdfs3-ctypes/hdfs.pyc in get_block_locations(self, path, start, length)
    117         fi = self.info(path)
    118         start = int(start) or 0
--> 119         length = int(length) or fi['size']
    120         nblocks = ctypes.c_int(0)
    121         out = lib.hdfsGetFileBlockLocations(self._handle, ensure_byte(path),

TypeError: int() argument must be a string or a number, not 'NoneType'
```