### PR TITLE
Textmode - includes readline and readlines, and iteration

### DIFF
--- a/hdfs.py
+++ b/hdfs.py
@@ -301,6 +301,8 @@ class HDFile():
     _fs = None
     path = None
     mode = None
+    encoding = 'ascii'
+    buffer = b''
     
     def __init__(self, fs, path, mode, repl=1, offset=0, buff=0):
         "Called by open on a HDFileSystem"
@@ -319,17 +321,44 @@ class HDFile():
             self.seek(offset)
     
     def read(self, length=2**16):
-        "Read, in chunks no bigger than the native filesystem (e.g., 64kb)"
+        "Read, binary chunks no bigger than the native filesystem (e.g., 64kb)"
         assert lib.hdfsFileIsOpenForRead(self._handle), 'File not read mode'
-        # TODO: read in chunks greater than block size by multiple
-        # calls to read
-        # TODO: consider tell() versuss filesize to determine bytes available.
         p = ctypes.create_string_buffer(length)
         ret = lib.hdfsRead(self._fs, self._handle, p, ctypes.c_int32(length))
         if ret >= 0:
             return p.raw[:ret]
         else:
             raise IOError('Read Failed:', -ret)
+
+    def readline(self):
+        "Read a buffered line, text mode."
+        if not hasattr(self, 'buffer'):
+            raise ValueError('File not in text mode')
+        lines = getattr(self, 'lines', [])
+        if len(lines) < 1:
+            buff = self.read()
+            if len(buff) == 0:   #EOF
+                remains = self.buffer.decode(self.encoding)
+                if remains:
+                    self.buffer = b''
+                    return remains
+                raise EOFError
+            buff = (self.buffer + buff).decode(self.encoding)
+            self.lines = buff.split('\n')
+        return self.lines.pop(0)
+
+    def _genline(self):
+        while True:
+            try:
+                yield self.readline()
+            except EOFError:
+                raise StopIteration
+    
+    def __iter__(self):
+        return self._genline()
+    
+    def readlines(self):
+        return list(self)
     
     def tell(self):
         out = lib.hdfsTell(self._fs, self._handle)


### PR DESCRIPTION
No enforcement of binary versus text more - a seek or read will
mess up line buffering.